### PR TITLE
Add settings for control count featured proposals

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -111,7 +111,7 @@ class ProposalsController < ApplicationController
 
     def load_featured
       return unless !@advanced_search_terms && @search_terms.blank? && @tag_filter.blank? && params[:retired].blank?
-      @featured_proposals = Proposal.not_archived.sort_by_confidence_score.limit(3)
+      @featured_proposals = Proposal.not_archived.sort_by_confidence_score.limit(Setting['count_featured_proposals'].presence.to_i|| 3)
       if @featured_proposals.present?
         set_featured_proposal_votes(@featured_proposals)
         @resources = @resources.where('proposals.id NOT IN (?)', @featured_proposals.map(&:id))

--- a/db/migrate/20170908045741_add_count_featured_proposal_to_settings.rb
+++ b/db/migrate/20170908045741_add_count_featured_proposal_to_settings.rb
@@ -1,0 +1,5 @@
+class AddCountFeaturedProposalToSettings < ActiveRecord::Migration
+  def change
+    execute "INSERT INTO settings (key, value) VALUES ('count_featured_proposals', 3);"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170719174326) do
+ActiveRecord::Schema.define(version: 20170908045741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
What
====
- New setting `count_featured_proposals` allows controlling count featured proposals in yellow block on proposals page. If we don't want this block we can set 0 for example


Deployment
==========
- As before

Warnings
========
- No
